### PR TITLE
Update drag-drop to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "buffer": "^5.2.1",
     "core-js": "^3.0.1",
     "debug": "^4.1.0",
-    "drag-drop": "^4.2.0",
+    "drag-drop": "^5.0.1",
     "music-metadata-browser": "^1.3.0",
     "process": "^0.11.10",
     "rxjs": "^6.3.2",


### PR DESCRIPTION
Update drag-drop to version 5.0.1, drop flatten dependency: feross/drag-drop#48

Live version: https://update-drag-drop--audio-tag-analyzer.netlify.com